### PR TITLE
Reduce noisy mount output to help spot actual problems

### DIFF
--- a/vast-perf.sh
+++ b/vast-perf.sh
@@ -91,6 +91,7 @@ DIRECT=1 # o_direct or not..
 ADMINUSER="admin"
 ADMINPASSWORD=123456
 LOOPBACK=1 # only applies when running on cnodes. default is on now. BUT: this requires a lot of vips..
+VERBOSE=1 # verbosely output details, may be too noisy on large clusters
 
 ###experimental flags ###
 CN_AVOID_ISL=0 # only set this to 1 if you are in the lab or know what you are doing. if there are bugs, it can screw up routing.
@@ -165,7 +166,9 @@ mount_func () {
       mount_cmd="sudo mount -v -t nfs -o retry=0,proto=rdma,soft,port=20049,vers=3 ${i}:${NFSEXPORT} ${MOUNT}/${i}"
       mount_output=$(eval $mount_cmd 2>&1)
       if [ $? -eq 0 ]; then
-        echo "mounted ${MOUNT}/${i} ok"
+        if [ ${VERBOSE} -eq 1 ]; then
+          echo "mounted ${MOUNT}/${i} ok"
+        fi
       else
         echo "mount of ${MOUNT}/${i} failed : $? , going to unmount everything and exit"
         echo "Command: $mount_cmd"
@@ -178,7 +181,9 @@ mount_func () {
       mount_cmd="sudo mount -v -t nfs -o retry=0,tcp,soft,rw,vers=3 ${i}:${NFSEXPORT} ${MOUNT}/${i}"
       mount_output=$(eval $mount_cmd 2>&1)
       if [ $? -eq 0 ]; then
-        echo "mounted ${MOUNT}/${i} ok"
+        if [ ${VERBOSE} -eq 1 ]; then
+          echo "mounted ${MOUNT}/${i} ok"
+        fi
       else
         echo "mount of ${MOUNT}/${i} failed : $? , going to unmount everything and exit"
         echo "Command: $mount_cmd"
@@ -405,6 +410,9 @@ while [ $# -gt 0 ]; do
     --password=*)
       ADMINPASSWORD="${1#*=}"
       ;;
+    --verbose=*)
+      VERBOSE="${1#*=}"
+      ;;
     --vipfile=*)
       VIPFILE="${1#*=}"
       ;;
@@ -413,7 +421,7 @@ while [ $# -gt 0 ]; do
       ;;
     *)
       printf "***************************\n"
-      printf "* Usage: vast-perf.sh [ --vms=x.x.x.x ] \n"
+      printf "* Usage: vast-perf.sh [--verbose=1] [ --vms=x.x.x.x ] \n"
       printf "* [ --export=/ ] [ --test=read_bw ] [ --runtime=120 ]\n"
       printf "* [--proto=tcp ] [ --jobs=8 ] [ --pool=1 ] \n"
       printf "* [--path=fiotest ] [--binary=/usr/bin/fio ] [--mountpoint=/mnt/fiotest ] \n"

--- a/vast-perf.sh
+++ b/vast-perf.sh
@@ -156,24 +156,34 @@ mount_func () {
   DIRS=()
   MD_DIRS=()
 
+  # Do the mounts. Stash away the command and the verbose output format
+  # but only output them on mount failure to reduce noise.
+
   for i in ${needed_vips[@]}; do
     sudo mkdir -p ${MOUNT}/${i}
     if [[ ${PROTO} == "rdma" ]]; then
-      echo "sudo mount -v -t nfs -o retry=0,proto=rdma,soft,port=20049,vers=3 ${i}:${NFSEXPORT} ${MOUNT}/${i}"
-      sudo mount -v -t nfs -o retry=0,proto=rdma,soft,port=20049,vers=3 ${i}:${NFSEXPORT} ${MOUNT}/${i}
+      mount_cmd="sudo mount -v -t nfs -o retry=0,proto=rdma,soft,port=20049,vers=3 ${i}:${NFSEXPORT} ${MOUNT}/${i}"
+      mount_output=$(eval $mount_cmd 2>&1)
       if [ $? -eq 0 ]; then
-        echo "mounted ${MOUNT} ok"
+        echo "mounted ${MOUNT}/${i} ok"
       else
-        echo "mount of ${MOUNT} failed : $? , going to unmount everything and exit"
-        #cleanup
+        echo "mount of ${MOUNT}/${i} failed : $? , going to unmount everything and exit"
+        echo "Command: $mount_cmd"
+        echo "Output:"
+        echo "$mount_output"
+        cleanup
         exit
       fi
     else
-      sudo mount -v -t nfs -o retry=0,tcp,soft,rw,vers=3 ${i}:${NFSEXPORT} ${MOUNT}/${i}
+      mount_cmd="sudo mount -v -t nfs -o retry=0,tcp,soft,rw,vers=3 ${i}:${NFSEXPORT} ${MOUNT}/${i}"
+      mount_output=$(eval $mount_cmd 2>&1)
       if [ $? -eq 0 ]; then
-        echo "mounted ${MOUNT} ok"
+        echo "mounted ${MOUNT}/${i} ok"
       else
-        echo "mount of ${MOUNT} failed : $? , going to unmount everything and exit"
+        echo "mount of ${MOUNT}/${i} failed : $? , going to unmount everything and exit"
+        echo "Command: $mount_cmd"
+        echo "Output:"
+        echo "$mount_output"
         cleanup
         exit
       fi
@@ -183,8 +193,6 @@ mount_func () {
     sudo mkdir -p ${fio_dir}
     sudo chmod 777 ${fio_dir}
   done
-
-  echo ${DIRS}
 }
 
 multipath_func () {


### PR DESCRIPTION
This PR does 3 primary things (each in a separate commit):
1. Groups all `PROTO` adjustments together instead of in 2 places -- there should be no functional change in the `PROTO`-determining logic if I've done my job right. Upside is that we only output one line about which protocol we're going to use instead of many.
2. Reduces noisy mount output to only show the full mount `-vv` output on failures.
3. Adds a `VERBOSE` flag, enabled by default, that can be disabled to further reduce mount noise.

The reduced output in the success path makes it easier to spot actual problems when running against larger clusters.

Ancillary changes with the above:
* `FORCE_RDMA` variable is removed as it was only used in commented out code that has been removed
* `IS_BCM` variable is removed as it was set but never used.
* On mount failure with `PROTO=tcp` the script now runs `cleanup` -- this now matches what is done for `PROTO=rdma` as they should match. If we'd rather it not cleanup in this case I can remove it from both instead.